### PR TITLE
Add landing page and shared styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pietro Scik · Designer &amp; Developer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-content">
+        <a class="brand" href="#hero">Pietro Scik</a>
+        <nav class="primary-nav" aria-label="Navigazione principale">
+          <ul>
+            <li><a href="#about">About</a></li>
+            <li><a href="#skills">Skills</a></li>
+            <li><a href="#projects">Progetti</a></li>
+            <li><a href="#testimonials">Testimonianze</a></li>
+            <li><a href="#contact">Contatti</a></li>
+            <li><a href="./status.html" class="status-link">Status</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section id="hero" class="hero">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">Designer &amp; Frontend Developer</p>
+            <h1>Ciao, sono Pietro Scik</h1>
+            <p>
+              Creo esperienze digitali accessibili e orientate alle persone per
+              startup e brand in crescita. Collaboriamo per trasformare la tua
+              idea in un prodotto memorabile.
+            </p>
+            <div class="hero-cta">
+              <a class="btn primary" href="#contact">Parliamo del tuo progetto</a>
+              <a class="btn secondary" href="mailto:ciao@pietroscik.dev"
+                >ciao@pietroscik.dev</a
+              >
+            </div>
+          </div>
+          <figure class="hero-media">
+            <img
+              src="./portrait.svg"
+              alt="Ritratto stilizzato di Pietro Scik"
+              width="480"
+              height="480"
+            />
+          </figure>
+        </div>
+      </section>
+
+      <section id="about" class="section about">
+        <div class="container">
+          <div class="section-header">
+            <h2>About</h2>
+            <p>Un mix di creatività e attenzione ai dettagli.</p>
+          </div>
+          <div class="section-content">
+            <p>
+              Negli ultimi 6 anni ho aiutato aziende tecnologiche e agenzie a
+              costruire esperienze digitali eleganti e misurabili. Mi muovo tra
+              design system, micro-interazioni e codice, per accompagnare i team
+              dalla strategia al lancio.
+            </p>
+            <p>
+              Amo lavorare con team curiosi, sperimentare e iterare rapidamente
+              per consegnare prodotti che funzionano davvero.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="skills" class="section skills">
+        <div class="container">
+          <div class="section-header">
+            <h2>Skills &amp; Servizi</h2>
+            <p>Come posso aiutarti.</p>
+          </div>
+          <div class="skills-grid">
+            <article class="card">
+              <h3>Product Design</h3>
+              <p>
+                Ricerca, user flow, wireframe e design system per prodotti SaaS e
+                piattaforme multi-device.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Frontend Development</h3>
+              <p>
+                Implementazione responsive, accessibile e performante con React,
+                Next.js e design system modulari.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Brand &amp; Visual</h3>
+              <p>
+                Identità visive coerenti e storytelling per lanciare o
+                riposizionare il tuo brand.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="projects" class="section projects">
+        <div class="container">
+          <div class="section-header">
+            <h2>Progetti</h2>
+            <p>Una selezione di lavori recenti.</p>
+          </div>
+          <div class="projects-grid">
+            <article class="card">
+              <h3>Flowdash</h3>
+              <p>
+                Dashboard SaaS per la gestione di workflow complessi.
+                Rebranding, UX/UI e sviluppo frontend.
+              </p>
+              <a href="#contact" class="inline-link">Scopri di più</a>
+            </article>
+            <article class="card">
+              <h3>Travelease</h3>
+              <p>
+                App mobile per prenotazioni business travel. Discovery, design
+                system e prototipazione ad alta fedeltà.
+              </p>
+              <a href="#contact" class="inline-link">Scopri di più</a>
+            </article>
+            <article class="card">
+              <h3>Bloomly</h3>
+              <p>
+                E-commerce florovivaistico con esperienza personalizzata e
+                checkout semplificato.
+              </p>
+              <a href="#contact" class="inline-link">Scopri di più</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="testimonials" class="section testimonials">
+        <div class="container">
+          <div class="section-header">
+            <h2>Testimonianze</h2>
+            <p>Le parole dei partner con cui ho collaborato.</p>
+          </div>
+          <div class="testimonials-grid">
+            <figure class="testimonial">
+              <blockquote>
+                «Pietro ha portato chiarezza strategica e cura per i dettagli. Il
+                nostro prodotto ha trovato una nuova identità.»
+              </blockquote>
+              <figcaption>— Laura Bianchi, CPO @ Flowdash</figcaption>
+            </figure>
+            <figure class="testimonial">
+              <blockquote>
+                «Collaborare con Pietro significa ottenere risultati rapidi e
+                misurabili, sempre in linea con gli obiettivi.»
+              </blockquote>
+              <figcaption>— Marco Rossi, CEO @ Travelease</figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section contact">
+        <div class="container">
+          <div class="section-header">
+            <h2>Contatti</h2>
+            <p>
+              Pronto a dare forma alla tua prossima esperienza digitale? Scrivimi
+              o prenota una call.
+            </p>
+          </div>
+          <div class="contact-grid">
+            <a class="contact-link" href="mailto:ciao@pietroscik.dev">
+              <span aria-hidden="true">✉️</span>
+              ciao@pietroscik.dev
+            </a>
+            <a class="contact-link" href="https://cal.com/pietroscik" target="_blank" rel="noreferrer">
+              <span aria-hidden="true">📅</span>
+              Prenota una call
+            </a>
+            <a class="contact-link" href="https://www.linkedin.com/in/pietroscik" target="_blank" rel="noreferrer">
+              <span aria-hidden="true">💼</span>
+              LinkedIn
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-content">
+        <p>© <span id="year"></span> Pietro Scik. Tutti i diritti riservati.</p>
+        <a href="./status.html" class="status-link">Status monitor</a>
+      </div>
+    </footer>
+
+    <script>
+      const yearEl = document.getElementById("year");
+      if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/public/portrait.svg
+++ b/public/portrait.svg
@@ -1,0 +1,26 @@
+<svg width="480" height="480" viewBox="0 0 480 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="480" rx="32" fill="url(#grad)" />
+  <g filter="url(#shadow)">
+    <circle cx="240" cy="170" r="76" fill="white" fill-opacity="0.92" />
+    <rect x="150" y="230" width="180" height="150" rx="60" fill="white" fill-opacity="0.92" />
+  </g>
+  <path
+    d="M220 198C220 183 232 171 247 171H247C262 171 274 183 274 198V210C274 225 262 237 247 237H247C232 237 220 225 220 210V198Z"
+    fill="#0F172A"
+    opacity="0.85"
+  />
+  <path
+    d="M193 276C193 258 208 243 226 243H254C272 243 287 258 287 276V304C287 322 272 337 254 337H226C208 337 193 322 193 304V276Z"
+    fill="#0F172A"
+    opacity="0.75"
+  />
+  <defs>
+    <linearGradient id="grad" x1="60" y1="60" x2="420" y2="420" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EA5E9" />
+      <stop offset="1" stop-color="#6366F1" />
+    </linearGradient>
+    <filter id="shadow" x="120" y="84" width="240" height="326" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" />
+    </filter>
+  </defs>
+</svg>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,319 @@
+:root {
+  --color-bg: #0f172a;
+  --color-surface: #111c34;
+  --color-surface-alt: #13213f;
+  --color-accent: #38bdf8;
+  --color-accent-strong: #6366f1;
+  --color-text: #f8fafc;
+  --color-text-muted: #cbd5f5;
+  --font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --container-width: min(1100px, 90vw);
+  --transition: 180ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: var(--container-width);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  backdrop-filter: blur(10px);
+  background: rgba(15, 23, 42, 0.75);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+}
+
+.brand {
+  font-weight: 900;
+  font-size: 1.3rem;
+  letter-spacing: 0.02em;
+}
+
+.primary-nav ul {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.primary-nav a {
+  font-weight: 500;
+  color: var(--color-text-muted);
+  transition: color var(--transition);
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus-visible {
+  color: var(--color-text);
+}
+
+.hero {
+  padding: 8rem 0 6rem;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hero-copy h1 {
+  margin-top: 0.25rem;
+  font-size: clamp(2.8rem, 5vw, 4rem);
+  line-height: 1.1;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  color: var(--color-accent);
+  font-size: 0.8rem;
+}
+
+.hero-cta {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn {
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  transition: transform var(--transition), background var(--transition),
+    color var(--transition), border-color var(--transition);
+}
+
+.btn.primary {
+  background: linear-gradient(120deg, var(--color-accent), var(--color-accent-strong));
+  color: var(--color-bg);
+}
+
+.btn.primary:hover,
+.btn.primary:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(15, 23, 42, 0.12);
+}
+
+.btn.secondary {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--color-text);
+}
+
+.btn.secondary:hover,
+.btn.secondary:focus-visible {
+  border-color: var(--color-text);
+  transform: translateY(-2px);
+}
+
+.hero-media {
+  justify-self: center;
+}
+
+.section {
+  padding: 5rem 0;
+  background: var(--color-surface);
+  border-top: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.section:nth-of-type(even) {
+  background: var(--color-surface-alt);
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+}
+
+.section-header p {
+  color: var(--color-text-muted);
+  margin-top: 0.5rem;
+  max-width: 520px;
+}
+
+.section-content {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.skills-grid,
+.projects-grid,
+.testimonials-grid,
+.contact-grid {
+  margin-top: 3rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card,
+.testimonial {
+  padding: 2rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 20px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
+}
+
+.card h3,
+.testimonial blockquote {
+  margin-top: 0;
+}
+
+.inline-link {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.inline-link::after {
+  content: '↗';
+  font-size: 0.9rem;
+  transition: transform var(--transition);
+}
+
+.inline-link:hover::after,
+.inline-link:focus-visible::after {
+  transform: translate(3px, -3px);
+}
+
+.contact {
+  text-align: center;
+}
+
+.contact-grid {
+  justify-items: center;
+}
+
+.contact-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.6rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--color-text);
+  font-weight: 600;
+  transition: transform var(--transition), border-color var(--transition),
+    background var(--transition), color var(--transition);
+}
+
+.contact-link:hover,
+.contact-link:focus-visible {
+  transform: translateY(-4px);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.site-footer {
+  padding: 2rem 0 3rem;
+  text-align: center;
+  background: var(--color-bg);
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.footer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.status-link {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.status-link:hover,
+.status-link:focus-visible {
+  color: var(--color-accent-strong);
+}
+
+@media (max-width: 900px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-cta {
+    justify-content: center;
+  }
+
+  .primary-nav ul {
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .header-content {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .primary-nav ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .section {
+    padding: 4rem 0;
+  }
+
+  .card,
+  .testimonial {
+    padding: 1.6rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a complete portfolio landing page at public/index.html with navigation, hero, and content sections
- include dedicated styles and palette definitions in public/styles.css to support responsive layout
- add a lightweight portrait SVG asset referenced by the hero section

## Testing
- curl -s http://localhost:4173/
- curl -sL http://localhost:4173/status.html

------
https://chatgpt.com/codex/tasks/task_e_68dab375daa0832da4f9fe0c4d45ffc3